### PR TITLE
Overwrite existing zip

### DIFF
--- a/src/lookupStream.js
+++ b/src/lookupStream.js
@@ -159,10 +159,7 @@ function createLookupStream(resolver, config) {
       if ( result.postalcode ) {
         var postalcode = result.postalcode[0].name;
         if (postalcode && postalcode !== '') {
-          var zip = doc.getAddress('zip');
-          if (!zip || zip === '') {
-            doc.setAddress('zip', postalcode);
-          }
+          doc.setAddress('zip', postalcode);
         }
       }
 


### PR DESCRIPTION
Postalcode/zip mapping is a configurable option. There is no reason
to preserve existing zip if mapping is enabled.
